### PR TITLE
Tidy up themes and styles and such

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -3,7 +3,7 @@ import { Drawer } from 'expo-router/drawer';
 import { Authenticator, useAuthenticator } from "@aws-amplify/ui-react-native";
 import { Amplify } from "aws-amplify";
 import { DataProvider } from "@/DataContext";
-import { PaperProvider } from "react-native-paper";
+import { MD3LightTheme, PaperProvider } from "react-native-paper";
 
 Amplify.configure({
   Auth: {
@@ -20,10 +20,12 @@ Amplify.configure({
 });
 
 export default function RootLayout() {
+  const paperTheme = MD3LightTheme;
+  
   return (
     <Authenticator.Provider>
       <Authenticator>
-        <PaperProvider>
+        <PaperProvider theme={paperTheme}>
           <DataProvider>
             <GestureHandlerRootView style={{ flex: 1 }}>
               <Drawer>

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -3,7 +3,8 @@ import { Drawer } from 'expo-router/drawer';
 import { Authenticator, useAuthenticator } from "@aws-amplify/ui-react-native";
 import { Amplify } from "aws-amplify";
 import { DataProvider } from "@/DataContext";
-import { MD3LightTheme, PaperProvider } from "react-native-paper";
+import { MD3LightTheme, MD3Theme, PaperProvider } from "react-native-paper";
+import { Theme as NavigationTheme, ThemeProvider } from "@react-navigation/native";
 
 Amplify.configure({
   Auth: {
@@ -21,38 +22,78 @@ Amplify.configure({
 
 export default function RootLayout() {
   const paperTheme = MD3LightTheme;
-  
+
+  /** Following the example from `react-native-paper/src/core/theming.tsx`, convert an MD3Theme into a NavigationTheme */
+  const getMirroredReactNavigationTheme = (baseTheme: MD3Theme): NavigationTheme => {
+    const reactNavigationRegularFontMirror = {
+      fontFamily: paperTheme.fonts.bodySmall.fontFamily,
+      fontWeight: paperTheme.fonts.bodySmall.fontWeight || "normal"
+    }
+    
+    const reactNavigationBoldFontMirror = {
+      fontFamily: paperTheme.fonts.titleSmall.fontFamily,
+      fontWeight: paperTheme.fonts.titleSmall.fontWeight || "normal"
+    }
+
+    return {
+    dark: baseTheme.dark,
+    colors: {
+      primary: paperTheme.colors.primary,
+      background: paperTheme.colors.surface,
+      card: paperTheme.colors.elevation.level2,
+      text: paperTheme.colors.onSurface,
+      border: paperTheme.colors.outlineVariant,
+      notification: paperTheme.colors.error
+    },
+    fonts: {
+      regular: reactNavigationRegularFontMirror,
+      medium: reactNavigationRegularFontMirror,
+      bold: reactNavigationBoldFontMirror,
+      heavy: reactNavigationBoldFontMirror,
+    }
+    }
+  }
+
+  // This unfortunate double-theming is necessary because expo-router does not directly integrate with react-native-paper.
+  // expo-router uses react-navigation under the hood to perform navigation, which provides its own themed styles to the
+  // react-navigation sub-components that expo-router wraps and provides. In order to standardize styles across the entire
+  // application, we have to convert our core themes (from react-native-paper) to react-navigation style themes. We use an
+  // approach very similar to what react-native-paper recommends, but with some slight tweaks.
+  const reactNavigationTheme = getMirroredReactNavigationTheme(paperTheme)
+
   return (
     <Authenticator.Provider>
       <Authenticator>
         <PaperProvider theme={paperTheme}>
-          <DataProvider>
-            <GestureHandlerRootView style={{ flex: 1 }}>
-              <Drawer>
-                <Drawer.Screen
-                  name="index"
-                  options={{
-                    drawerLabel: "Home",
-                    title: "Home",
-                  }}
-                />
-                <Drawer.Screen
-                  name="counts"
-                  options={{
-                    drawerLabel: "Counts",
-                    title: "Counts",
-                  }}
-                />
-                <Drawer.Screen
-                  name="grants"
-                  options={{
-                    drawerLabel: "Packs",
-                    title: "Packs",
-                  }}
-                />
-              </Drawer>
-            </GestureHandlerRootView>
-          </DataProvider>
+          <ThemeProvider value={reactNavigationTheme}>
+            <DataProvider>
+              <GestureHandlerRootView style={{ flex: 1 }}>
+                <Drawer>
+                  <Drawer.Screen
+                    name="index"
+                    options={{
+                      drawerLabel: "Home",
+                      title: "Home",
+                    }}
+                  />
+                  <Drawer.Screen
+                    name="counts"
+                    options={{
+                      drawerLabel: "Counts",
+                      title: "Counts",
+                    }}
+                  />
+                  <Drawer.Screen
+                    name="grants"
+                    options={{
+                      drawerLabel: "Packs",
+                      title: "Packs",
+                    }}
+                  />
+                </Drawer>
+              </GestureHandlerRootView>
+            </DataProvider>
+          </ThemeProvider>
         </PaperProvider>
       </Authenticator>
     </Authenticator.Provider>

--- a/app/counts.tsx
+++ b/app/counts.tsx
@@ -1,7 +1,7 @@
-import { Button, Text, View, StyleSheet, ActivityIndicator, ScrollView } from "react-native";
 import { useData } from "@/DataContext";
 import { useEffect, useState } from "react";
-import { DataTable } from "react-native-paper";
+import { StyleSheet, View } from "react-native";
+import { ActivityIndicator, DataTable } from "react-native-paper";
 
 export default function Counts() {
   const { numberToCountMap,  isLoading } = useData();
@@ -9,7 +9,7 @@ export default function Counts() {
   if (isLoading) {
     return (
         <View style={styles.container}>
-            <ActivityIndicator size="large" color="#fff" />
+            <ActivityIndicator size="large" />
         </View>
     )
   }
@@ -106,62 +106,12 @@ export default function Counts() {
         />
       </DataTable>
   )
-
-  const rows = sortedNumbers.map((number) => (
-    <View key={number} style={styles.row}>
-        <View style={styles.rowView}>
-            <Text style={styles.text}>{number}</Text>
-        </View>
-        <View style={styles.rowView}>
-            <Text style={styles.text}>{numberToCountMap.get(number)}</Text>
-        </View>
-    </View>
-  ));
-
-  return (
-    <View style={styles.container}>
-        <View style={styles.row}>
-            <View style={styles.rowView}>
-                <Text style={styles.tableHeader}>Number</Text>
-            </View>
-            <View style={styles.rowView}>
-                <Text style={styles.tableHeader}>Count</Text>
-            </View>
-        </View>
-        <ScrollView>
-            {rows}
-        </ScrollView>
-    </View>
-  )
 }
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: "#25292e",
     justifyContent: "center",
     alignItems: "center",
-  },
-  row: {
-    flexDirection: "row",
-  },
-  text: {
-    flex: 1,
-    color: '#fff',
-    fontSize: 20,
-    borderWidth: 1,
-    borderColor: "#fff",
-    textAlign: "right",
-    padding: 5,
-  },
-  tableHeader: {
-    color: '#fff',
-    fontSize: 20,
-    fontWeight: "bold",
-    textAlign: "center",
-    padding: 5,
-  },
-  rowView: {
-    width: 120,
   }
 });

--- a/app/grants.tsx
+++ b/app/grants.tsx
@@ -1,7 +1,7 @@
-import { Button, Text, View, StyleSheet, ActivityIndicator, ScrollView } from "react-native";
+import { View, StyleSheet } from "react-native";
 import { useData } from "@/DataContext";
 import { Grant } from "@/model/Grant";
-import { DataTable } from "react-native-paper";
+import { ActivityIndicator, DataTable } from "react-native-paper";
 import { useEffect, useState } from "react";
 
 export default function Grants() {
@@ -10,7 +10,7 @@ export default function Grants() {
     if (isLoading) {
       return (
           <View style={styles.container}>
-              <ActivityIndicator size="large" color="#fff" />
+              <ActivityIndicator size="large" style={{paddingTop: 32}} />
           </View>
       )
     }
@@ -68,54 +68,10 @@ export default function Grants() {
         />
       </DataTable>
     );
-
-    // const reversedGrants = [...grants].reverse();
-
-    // const rows = reversedGrants.map((grant) => (
-    //   <View key={grant.timestamp.toString()} style={styles.row}>
-    //       <View style={styles.rowView}>
-    //           <Text style={styles.text}>{grant.timestamp.toLocaleString()}</Text>
-    //       </View>
-    //       <View style={styles.rowView}>
-    //           <Text style={styles.text}>{getGrantString(grant)}</Text>
-    //       </View>
-    //   </View>
-    // ));
-
-    // return (
-    //     <View style={styles.container}>
-    //         <ScrollView>
-    //             {rows}
-    //         </ScrollView>
-    //     </View>
-    // )
 }
 
 const styles = StyleSheet.create({
   container: {
-    flex: 1,
-    backgroundColor: "#25292e",
-  },
-  row: {
-    flexDirection: "row",
-  },
-  text: {
-    flex: 1,
-    color: '#fff',
-    fontSize: 14,
-    borderWidth: 1,
-    borderColor: "#fff",
-    textAlign: "right",
-    padding: 5,
-  },
-  tableHeader: {
-    color: '#fff',
-    fontSize: 14,
-    fontWeight: "bold",
-    textAlign: "center",
-    padding: 5,
-  },
-  rowView: {
     flex: 1,
   }
 });

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,4 +1,4 @@
-import { Button, Text, View, StyleSheet, ActivityIndicator } from "react-native";
+import { View, StyleSheet } from "react-native";
 import { useNavigation } from "expo-router";
 import GridCarouselView from "@/components/GridCarouselView";
 import { useAuthenticator } from "@aws-amplify/ui-react-native";
@@ -7,12 +7,12 @@ import { useData } from "@/DataContext";
 import GrantButtonView from "@/components/GrantButtonView";
 import NewGrantCarouselView from "@/components/NewGrantCarouselView";
 import createApiClient from "@/clients/apiClient";
+import { ActivityIndicator, Button, MD3DarkTheme, PaperProvider, Text, useTheme } from "react-native-paper";
 
 export default function Index() {
   const { signOut } = useAuthenticator();
   const navigation = useNavigation();
   const { user } = useAuthenticator();
-
   useEffect(() => {
     navigation.setOptions({
       headerRight: () => (
@@ -21,35 +21,54 @@ export default function Index() {
         }}>
           <Button
             onPress={signOut}
-            title="Sign out"
-          />
+            mode="outlined"
+          >
+          Sign out
+          </Button>
         </View>
       )
     });
   }, []);
+
+
+  // The landing page intentionally and explicitly uses the "dark" theme for contrast with the
+  // other pages. This means that it is not dynamically styled based on the users dark / light
+  // color preference.
+  const darkTheme = MD3DarkTheme
+  const styles = getStyles(darkTheme.colors.background)
+
+  /** 
+   * Wraps the given element in its own PaperProvider, which detaches it from the regular user
+   * preference for theme color.
+   */
+  const wrapInDarkThemeOverride = (element: React.JSX.Element): React.JSX.Element => {
+    return (
+        <PaperProvider theme={darkTheme}>{element}</PaperProvider>
+    )
+  } 
 
   const [isNewGrantView, setIsNewGrantView] = useState<boolean>(false);
   const [newNumbers, setNewNumbers] = useState<{number: number, isNew: boolean}[]>([]);
   const { numberToCountMap,  isLoading, refreshData } = useData();
 
   if (isLoading) {
-      return (
+      return wrapInDarkThemeOverride(
           <View style={styles.container}>
-              <ActivityIndicator size="large" color="#fff" />
+              <ActivityIndicator size="large" />
           </View>
       );
   }
 
   if (isNewGrantView) {
     if (newNumbers.length === 0) {
-      return (
+      return wrapInDarkThemeOverride(
         <View style={styles.container}>
-          <Text style={styles.header}>No new numbers available</Text>
+          <Text style={darkTheme.fonts.headlineSmall}>No new numbers available</Text>
         </View>
       );
     }
 
-    return (
+    return wrapInDarkThemeOverride(
       <View style={styles.container}>
         <NewGrantCarouselView newNumbers={newNumbers} onBackToGrid={() => setIsNewGrantView(false)} />
       </View>
@@ -72,33 +91,23 @@ export default function Index() {
     setIsNewGrantView(true);
   }
 
-  return (
+  return wrapInDarkThemeOverride(
     <View style={styles.container}>
-      <Text style={styles.header}>Your Number Collection</Text>
+      <Text variant="headlineSmall">Your Number Collection</Text>
       <GridCarouselView numberToCount={numberToCountMap} />
       <GrantButtonView onGetNewNumbersPress={handleGetNewNumbersPress} />
     </View>
   );
 }
 
-const styles = StyleSheet.create({
+const getStyles = (backgroundColor: string) => {
+  return StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: "#25292e",
+    backgroundColor,
     justifyContent: "center",
     alignItems: "center",
     gap: 20,
-  },
-  header: {
-    color: "#fff",
-    fontSize: 24,
-  },
-  text: {
-    color: "#fff",
-  },
-  button: {
-    fontSize: 20,
-    textDecorationLine: "underline",
-    color: "#fff",
-  },
-});
+  }
+  });
+}

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -35,7 +35,7 @@ export default function Index() {
   // other pages. This means that it is not dynamically styled based on the users dark / light
   // color preference.
   const darkTheme = MD3DarkTheme
-  const styles = getStyles(darkTheme.colors.background)
+  const styles = getStyles(darkTheme.colors.surface)
 
   /** 
    * Wraps the given element in its own PaperProvider, which detaches it from the regular user

--- a/components/GrantButtonView.tsx
+++ b/components/GrantButtonView.tsx
@@ -1,6 +1,7 @@
-import { ActivityIndicator, Button, Text, View, StyleSheet } from "react-native";
+import { View, StyleSheet } from "react-native";
 import { useData } from "@/DataContext";
 import { useEffect, useState } from "react";
+import { ActivityIndicator, Button, Text } from "react-native-paper";
 
 type GrantButtonViewProps = {
     onGetNewNumbersPress: () => void;
@@ -40,22 +41,20 @@ export default function GrantButtonView(props: GrantButtonViewProps) {
     if (isLoading || localIsLoading) {
         return (
             <View>
-                <ActivityIndicator size="large" color="#fff" />
+                <ActivityIndicator size="large" />
             </View>
         );
     }
 
     if (showGrantButton) {
-        return <Button title="Get New Numbers" onPress={props.onGetNewNumbersPress}></Button>
+        return <Button mode="contained" onPress={props.onGetNewNumbersPress}>Get New Numbers</Button>
     }
 
-    console.log(`XXXXXXXXXXX returning countdown view`);
     return (
-        <Text style={styles.countdown}>New numbers available in: {countdown}</Text>
+        <Text variant="titleMedium">New numbers available in: {countdown}</Text>
     )
 }
 
 const styles = StyleSheet.create({
     centered: { flex: 1, justifyContent: "center", alignItems: "center" },
-    countdown: { fontSize: 18, textAlign: "center", color: "#fff" },
 });

--- a/components/GridCarouselView.tsx
+++ b/components/GridCarouselView.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { TouchableHighlight, View } from "react-native";
 import GridView from "./GridView";
 import { AntDesign } from "@expo/vector-icons";
+import { useTheme } from "react-native-paper";
 
 type GridCarouselViewProps = {
     numberToCount: Map<number, number>;
@@ -14,8 +15,10 @@ export default function GridCarouselView(props: GridCarouselViewProps) {
     const maxNumber = Math.max(0, ...numberSet);
     const maxPageNumber = Math.floor(maxNumber / 100);
 
-    const leftColor = pageNumber === 0 ? "gray" : "white";
-    const rightColor = pageNumber === maxPageNumber ? "gray" : "white";
+    const theme = useTheme()
+
+    const leftColor = pageNumber === 0 ? theme.colors.onSurfaceDisabled : theme.colors.onSurface;
+    const rightColor = pageNumber === maxPageNumber ? theme.colors.onSurfaceDisabled : theme.colors.onSurface;
     const arrowSize = 36;
 
     return (

--- a/components/GridView.tsx
+++ b/components/GridView.tsx
@@ -1,5 +1,5 @@
-import { Text, View, StyleSheet } from "react-native";
-
+import { View, StyleSheet } from "react-native";
+import { Text } from "react-native-paper";
 type GridViewProps = {
     numberToCount: Map<number, number>;
     startNumber: number;
@@ -12,6 +12,8 @@ export default function GridView(props: GridViewProps) {
         const elements = [];
         for (let colIndex = 0; colIndex < 10; colIndex++) {
             const number = props.startNumber + rowIndex * 10 + colIndex;
+            // The below colors are not themed, because they are a core part of
+            // the existing visual identity of the app.
             const backgroundColor = numberSet.has(number) ? "green" : "#bbb";
             const color = numberSet.has(number) ? "white" : "gray";
             elements.push(
@@ -49,9 +51,6 @@ const styles = StyleSheet.create({
         flex: 1,
         justifyContent: "center",
         alignItems: "center",
-    },
-    text: {
-        color: "#fff",
     },
     cell: {
         width: 30,

--- a/components/NewGrantCarouselView.tsx
+++ b/components/NewGrantCarouselView.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
-import { Button, Text, TouchableHighlight, View } from "react-native";
+import { TouchableHighlight, View } from "react-native";
 import { AntDesign } from "@expo/vector-icons";
+import { Button, Text, TouchableRipple, useTheme } from "react-native-paper";
 
 type NewGrantCarouselViewProps = {
     newNumbers: {number: number, isNew: boolean}[];
@@ -16,30 +17,39 @@ export default function NewGrantCarouselView(props: NewGrantCarouselViewProps) {
 
     const sortedNumbers = props.newNumbers.map((n) => n.number).sort((a, b) => a - b);
 
-    const leftColor = cardIndex === 0 ? "gray" : "white";
-    const rightColor = cardIndex === sortedNumbers.length - 1 ? "gray" : "white";
+    const theme = useTheme()
+
+    const leftColor = cardIndex === 0 ? theme.colors.onSurfaceDisabled : theme.colors.onSurface;
+    const rightColor = cardIndex === sortedNumbers.length - 1 ? theme.colors.onSurfaceDisabled : theme.colors.onSurface;
     const arrowSize = 36;
+
+    // The built in react-native-paper fonts do not have a font large enough for this element, so we've gone a bit custom here.
+    const extraLargeFontStyles = {
+        ...theme.fonts.displayLarge,
+        fontSize: 100,
+        lineHeight: 120,
+    }
 
     return (
         <View style={{alignItems: "center", gap: 20}}>
-            <Text style={{color: "#fff", fontSize: 32}}>Your New Numbers</Text>
+            <Text variant="headlineLarge">Your New Numbers</Text>
             <View style={{flexDirection: "row", alignItems: "center"}}>
-                <TouchableHighlight onPress={() => setCardIndex(cardIndex - 1)} disabled={cardIndex === 0}>
+                <TouchableRipple onPress={() => setCardIndex(cardIndex - 1)} disabled={cardIndex === 0}>
                     <AntDesign name="left" color={leftColor} size={arrowSize}></AntDesign>
-                </TouchableHighlight>
-                <View style={{flexDirection: "column", alignItems: "center", justifyContent: "center", width: 180, height: 290, borderWidth: 1, borderColor: "#fff", borderRadius: 20}}>
-                    <Text style={{fontSize: 100, color: "#fff"}}>{sortedNumbers[cardIndex]}</Text>
+                </TouchableRipple>
+                <View style={{flexDirection: "column", alignItems: "center", justifyContent: "center", width: 180, height: 290, borderWidth: 1, borderColor: theme.colors.onSurface, borderRadius: 20}}>
+                    <Text style={extraLargeFontStyles}>{sortedNumbers[cardIndex]}</Text>
                     {
                         numberToNewMap.get(sortedNumbers[cardIndex]) &&
-                            <Text style={{fontSize: 24, color: "#fff"}}>NEW</Text>
+                            <Text variant="headlineSmall">NEW</Text>
                     }
                 </View>
-                <TouchableHighlight onPress={() => setCardIndex(cardIndex + 1)} disabled={cardIndex === sortedNumbers.length - 1}>
+                <TouchableRipple onPress={() => setCardIndex(cardIndex + 1)} disabled={cardIndex === sortedNumbers.length - 1}>
                     <AntDesign name="right" color={rightColor} size={arrowSize}></AntDesign>
-                </TouchableHighlight>
+                </TouchableRipple>
             </View>
-            <Text style={{color: "#fff", fontSize: 24}}>{cardIndex + 1}/{sortedNumbers.length}</Text>
-            <Button title="Back to Grid" onPress={props.onBackToGrid} />
+            <Text variant="headlineMedium">{cardIndex + 1}/{sortedNumbers.length}</Text>
+            <Button mode="contained" onPress={props.onBackToGrid}>Back to Grid</Button>
         </View>
     )
 }


### PR DESCRIPTION
Took a deep pass through the current styling, and switched everything over to properly using react-native-paper based themes as best as I could.

The default for new pages is now the default "light theme," which I have not further customized, but could be customized via a mechanism e.g. like https://callstack.github.io/react-native-paper/docs/guides/theming#simple-built-in-theme-overrides. For the landing page, I've overridden the default to the "dark theme" which matches the current app behavior.

I've visually reviewed every page to make sure they still look mostly the same, although some styles have naturally changed. Primarily, the styles for activity indicators and buttons are the most visually different.

Things to keep in mind to keep themes consistent going forwards for react-native-paper:
* When importing components, make sure to use the react-native-paper component equivalent instead of the base react-native version (many components exist in both)
* When styling, try to use the more dynamic declarations like I have throughout the commits

I think that's the majority of it! I'm going to go through and leave comments on notable changes commit by commit (if that's a thing on GitHub?) definitely feel free to leave questions so I can fill in any gaps. Also super open to tweaking the styles here and further customizing them, if you'd like!