### PR TITLE
Add card rarity color scheme and card view

### DIFF
--- a/components/CardView.tsx
+++ b/components/CardView.tsx
@@ -80,7 +80,7 @@ export default function CardView(props: CardViewProps) {
         width: 240,
         height: 340,
         borderWidth: 10,
-        borderColor: props.number < 0 ? foreground : "#ffffff66",
+        borderColor: props.number < 0 ? "#00000066" : "#ffffff66",
         borderRadius: 20,
         backgroundColor: background,
     }}>

--- a/components/CardView.tsx
+++ b/components/CardView.tsx
@@ -1,0 +1,139 @@
+import {TextStyle, View} from 'react-native';
+import {Text, useTheme} from 'react-native-paper';
+import {getCardColor} from '@/styles/getCardColor';
+import {StyleProp} from '@/node_modules/react-native/Libraries/StyleSheet/StyleSheet';
+import {ViewStyle} from '@/node_modules/react-native/Libraries/StyleSheet/StyleSheetTypes';
+import {convertToWords} from 'react-number-to-words';
+import {isPrime, isSquare} from '@/utils/math';
+
+type CardViewProps = {
+    number: number;
+    isNew: boolean;
+}
+
+export default function CardView(props: CardViewProps) {
+    const theme = useTheme();
+
+    // Map number to card color
+    // white/grey = common, green = uncommon, blue = rare, purple = very rare/mythical, orange = legendary
+    const {background, foreground} = getCardColor(props.number);
+    // Gradient from rarity color to white?
+
+    // The built in react-native-paper fonts do not have a font large enough for this element, so we've gone a bit custom here.
+    const extraLargeFontStyles: StyleProp<TextStyle> = {
+        ...theme.fonts.displayLarge,
+        fontSize: 80,
+        // lineHeight: 120,
+        color: foreground,
+        fontWeight: '900',
+    }
+
+    const boxStyle: StyleProp<ViewStyle> = {
+        borderColor: "#00000066",
+        backgroundColor: "#ffffff66",
+        borderTopColor: "#00000033",
+        borderTopWidth: 2,
+        borderLeftColor: "#00000033",
+        borderLeftWidth: 2,
+        borderBottomColor: "#ffffff33",
+        borderBottomWidth: 5,
+        borderRightColor: "#ffffff33",
+        borderRightWidth: 5,
+        width: '100%',
+        height: 200,
+        alignItems: 'center',
+        justifyContent: 'center',
+    };
+
+    const negativeStyleOverrides: StyleProp<ViewStyle> = {
+        backgroundColor: "transparent",
+        borderTopColor: "transparent",
+        borderLeftColor: "transparent",
+        borderBottomColor: "transparent",
+        borderRightColor: "transparent",
+    }
+
+    const iconStyle: StyleProp<ViewStyle> = {
+        borderRadius: '100%',
+        borderColor: '#00000099',
+        borderWidth: 1,
+        marginLeft: 8,
+        width: 16,
+        height: 16,
+    };
+
+    const iconTextStyle: StyleProp<TextStyle> = {
+        color: '#ffffff',
+        fontSize: 10,
+        fontWeight: 'bold',
+        textAlign: 'center',
+        lineHeight: 14,
+    };
+
+    const prime = isPrime(props.number);
+    const square = isSquare(props.number);
+
+    return <View style={{
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        width: 240,
+        height: 340,
+        borderWidth: 10,
+        borderColor: props.number < 0 ? foreground : "#ffffff66",
+        borderRadius: 20,
+        backgroundColor: background,
+    }}>
+        <View style={{
+            width: '100%',
+            padding: 8,
+            flexDirection: 'row',
+        }}>
+            <Text style={{
+                flex: 1,
+                ...theme.fonts.displaySmall,
+                fontSize: 12,
+                lineHeight: 16,
+                color: (props.number >= 0) ? '#000000' : '#ffffff',
+                fontWeight: 'bold',
+            }}>{props.number}</Text>
+            { prime &&
+                <View style={{
+                    ...iconStyle,
+                    backgroundColor: '#006600',
+                }}><Text style={iconTextStyle} accessibilityLabel="Prime Number">◊</Text></View>
+            }
+            { square &&
+                <View style={{
+                    ...iconStyle,
+                    backgroundColor: '#660000',
+                }}><Text style={iconTextStyle} accessibilityLabel="Square Number">▢</Text></View>
+            }
+        </View>
+        <View style={{
+            ...boxStyle,
+            ...(props.number < 0) ? negativeStyleOverrides : {},
+        }}>
+            <Text style={extraLargeFontStyles}>{props.number}</Text>
+       </View>
+        <View style={{
+            flex: 1,
+            width: '100%',
+            padding: 8,
+        }}>
+            <Text style={{
+                ...theme.fonts.displayMedium,
+                fontSize: 16,
+                lineHeight: 18,
+                fontStyle: 'italic',
+                color: (props.number >= 0) ? '#000000' : '#ffffff',
+            }}>
+                {(props.number < 0) ? 'Negative ' : ''}{convertToWords(Math.abs(props.number))}
+            </Text>
+        </View>
+        {
+                props.isNew &&
+                    <Text variant="headlineSmall" style={{fontSize: 14, fontWeight: 'bold', color: (props.number >= 0) ? '#000000' : '#ffffff'}}>*NEW*</Text>
+            }
+    </View>
+}

--- a/components/GridView.tsx
+++ b/components/GridView.tsx
@@ -1,4 +1,4 @@
-import { getCardColor } from "@/styles/getCardColor";
+import {getCardColor, getGridColor} from '@/styles/getCardColor';
 import { View, StyleSheet } from "react-native";
 import { Text } from "react-native-paper";
 type GridViewProps = {
@@ -16,7 +16,7 @@ export default function GridView(props: GridViewProps) {
             return {backgroundColor: "#bbb", color: "gray"};
         }
         // Get the colors for this number from its rarity
-        const {background, foreground} = getCardColor(number);
+        const {background, foreground} = getGridColor(number);
         return {backgroundColor: background, color: foreground};
     }
 

--- a/components/GridView.tsx
+++ b/components/GridView.tsx
@@ -15,8 +15,9 @@ export default function GridView(props: GridViewProps) {
         if (!numberSet.has(number)) {
             return {backgroundColor: "#bbb", color: "gray"};
         }
-        const backgroundColor = getCardColor(number);
-        return {backgroundColor, color: "white"};
+        // Get the colors for this number from its rarity
+        const {background, foreground} = getCardColor(number);
+        return {backgroundColor: background, color: foreground};
     }
 
     const rows = [];
@@ -33,7 +34,7 @@ export default function GridView(props: GridViewProps) {
                         backgroundColor,
                     }}
                 >
-                    <Text style={{color}}>{number}</Text>
+                    <Text style={{color, fontWeight: numberSet.has(number) ? 'bold' : 100}}>{number}</Text>
                 </View>
             );
         }

--- a/components/NewGrantCarouselView.tsx
+++ b/components/NewGrantCarouselView.tsx
@@ -1,8 +1,8 @@
 import { useState } from "react";
 import { View } from "react-native";
+import CardView from "./CardView";
 import { AntDesign } from "@expo/vector-icons";
 import { Button, Text, TouchableRipple, useTheme } from "react-native-paper";
-import { getCardColor } from "@/styles/getCardColor";
 
 type NewGrantCarouselViewProps = {
     newNumbers: {number: number, isNew: boolean}[];
@@ -24,13 +24,6 @@ export default function NewGrantCarouselView(props: NewGrantCarouselViewProps) {
     const rightColor = cardIndex === sortedNumbers.length - 1 ? theme.colors.onSurfaceDisabled : theme.colors.onSurface;
     const arrowSize = 36;
 
-    // The built in react-native-paper fonts do not have a font large enough for this element, so we've gone a bit custom here.
-    const extraLargeFontStyles = {
-        ...theme.fonts.displayLarge,
-        fontSize: 100,
-        lineHeight: 120,
-    }
-
     return (
         <View style={{alignItems: "center", gap: 20}}>
             <Text variant="headlineLarge">Your New Numbers</Text>
@@ -38,23 +31,7 @@ export default function NewGrantCarouselView(props: NewGrantCarouselViewProps) {
                 <TouchableRipple onPress={() => setCardIndex(cardIndex - 1)} disabled={cardIndex === 0}>
                     <AntDesign name="left" color={leftColor} size={arrowSize}></AntDesign>
                 </TouchableRipple>
-                <View style={{
-                    flexDirection: "column",
-                    alignItems: "center",
-                    justifyContent: "center",
-                    width: 180,
-                    height: 290,
-                    borderWidth: 1,
-                    borderColor: theme.colors.onSurface,
-                    borderRadius: 20,
-                    backgroundColor: getCardColor(sortedNumbers[cardIndex]),
-                }}>
-                    <Text style={extraLargeFontStyles}>{sortedNumbers[cardIndex]}</Text>
-                    {
-                        numberToNewMap.get(sortedNumbers[cardIndex]) &&
-                            <Text variant="headlineSmall">NEW</Text>
-                    }
-                </View>
+                <CardView number={sortedNumbers[cardIndex]} isNew={!!numberToNewMap.get(sortedNumbers[cardIndex])}></CardView>
                 <TouchableRipple onPress={() => setCardIndex(cardIndex + 1)} disabled={cardIndex === sortedNumbers.length - 1}>
                     <AntDesign name="right" color={rightColor} size={arrowSize}></AntDesign>
                 </TouchableRipple>

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,8 @@
         "react-native-screens": "~4.4.0",
         "react-native-vector-icons": "^10.2.0",
         "react-native-web": "~0.19.13",
-        "react-native-webview": "13.12.5"
+        "react-native-webview": "13.12.5",
+        "react-number-to-words": "^1.0.5"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
@@ -14600,6 +14601,11 @@
         "async-limiter": "~1.0.0"
       }
     },
+    "node_modules/react-number-to-words": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/react-number-to-words/-/react-number-to-words-1.0.5.tgz",
+      "integrity": "sha512-r1JtJgOYhD7/Trp7h0rDIw5Xl2dCykVAJgfKT/DaI1C/aedvbag4QiF/QjZG40DTEStrYbITleYeGIMbH6vCsQ=="
+    },
     "node_modules/react-refresh": {
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
@@ -28051,6 +28057,11 @@
         "escape-string-regexp": "^4.0.0",
         "invariant": "2.2.4"
       }
+    },
+    "react-number-to-words": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/react-number-to-words/-/react-number-to-words-1.0.5.tgz",
+      "integrity": "sha512-r1JtJgOYhD7/Trp7h0rDIw5Xl2dCykVAJgfKT/DaI1C/aedvbag4QiF/QjZG40DTEStrYbITleYeGIMbH6vCsQ=="
     },
     "react-refresh": {
       "version": "0.14.2",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "react-native-screens": "~4.4.0",
     "react-native-vector-icons": "^10.2.0",
     "react-native-web": "~0.19.13",
-    "react-native-webview": "13.12.5"
+    "react-native-webview": "13.12.5",
+    "react-number-to-words": "^1.0.5"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/styles/getCardColor.ts
+++ b/styles/getCardColor.ts
@@ -8,7 +8,7 @@ export type CardColor = {
 function cardBackgroundColor(rarity: Rarity): string {
   switch (rarity) {
     case Rarity.Trash:
-      return "#999999";
+      return "hsl(130, 0%, 46%)";
     case Rarity.Common:
       return "hsl(130, 60%, 46%)";
     case Rarity.Uncommon:
@@ -27,7 +27,7 @@ function cardBackgroundColor(rarity: Rarity): string {
 function gridBackgroundColor(rarity: Rarity): string {
   switch (rarity) {
     case Rarity.Trash:
-      return "#999999";
+      return "hsl(130, 0%, 26%)";
     case Rarity.Common:
       return "hsl(130, 60%, 26%)";
     case Rarity.Uncommon:
@@ -46,7 +46,7 @@ function gridBackgroundColor(rarity: Rarity): string {
 function negativeBackgroundColor(rarity: Rarity): string {
   switch (rarity) {
     case Rarity.Trash:
-      return "#999999";
+      return "hsl(130, 0%, 6%)";
     case Rarity.Common:
       return "hsl(130, 60%, 6%)";
     case Rarity.Uncommon:

--- a/styles/getCardColor.ts
+++ b/styles/getCardColor.ts
@@ -1,5 +1,39 @@
+import { Rarity, getCardRarity } from "@/utils/rarity";
+
+export type CardColor = {
+  background: string;
+  foreground: string;
+};
+
+function rarityColor(rarity: Rarity): string {
+  switch (rarity) {
+    case Rarity.Trash:
+      return "#eeeeee";
+    case Rarity.Common:
+      return "#999999";
+    case Rarity.Uncommon:
+      return "#00c400";
+    case Rarity.Rare:
+      return "#6d9eeb";
+    case Rarity.Mythical:
+      return "#ffe599";
+    case Rarity.Legendary:
+      return "#e69138";
+    case Rarity.Unique:
+      return "#ff00ff";
+  }
+}
+
 // The below colors are not themed, because they are a core part of
 // the existing visual identity of the app.
-export function getCardColor(number: number): string {
-    return number >= 0 ? "green" : "firebrick";
+export function getCardColor(number: number): CardColor {
+  const rarity = getCardRarity(number);
+  const color = rarityColor(rarity);
+
+  // Invert card colors for negative numbers
+  if (number >= 0) {
+    return { background: color, foreground: "#000000" };
+  } else {
+    return { background: "#000000", foreground: color };
+  }
 }

--- a/styles/getCardColor.ts
+++ b/styles/getCardColor.ts
@@ -5,22 +5,60 @@ export type CardColor = {
   foreground: string;
 };
 
-function rarityColor(rarity: Rarity): string {
+function cardBackgroundColor(rarity: Rarity): string {
   switch (rarity) {
     case Rarity.Trash:
-      return "#eeeeee";
-    case Rarity.Common:
       return "#999999";
+    case Rarity.Common:
+      return "hsl(130, 60%, 46%)";
     case Rarity.Uncommon:
-      return "#00c400";
+      return "hsl(220, 60%, 46%)";
     case Rarity.Rare:
-      return "#6d9eeb";
+      return "hsl(280, 60%, 46%)";
     case Rarity.Mythical:
-      return "#ffe599";
+      return "hsl(40, 60%, 46%)";
     case Rarity.Legendary:
-      return "#e69138";
+      return "hsl(10, 60%, 46%)";
     case Rarity.Unique:
-      return "#ff00ff";
+      return "hsl(190, 60%, 46%)";
+  }
+}
+
+function gridBackgroundColor(rarity: Rarity): string {
+  switch (rarity) {
+    case Rarity.Trash:
+      return "#999999";
+    case Rarity.Common:
+      return "hsl(130, 60%, 26%)";
+    case Rarity.Uncommon:
+      return "hsl(220, 60%, 26%)";
+    case Rarity.Rare:
+      return "hsl(280, 60%, 26%)";
+    case Rarity.Mythical:
+      return "hsl(40, 60%, 26%)";
+    case Rarity.Legendary:
+      return "hsl(10, 60%, 26%)";
+    case Rarity.Unique:
+      return "hsl(190, 60%, 26%)";
+  }
+}
+
+function negativeBackgroundColor(rarity: Rarity): string {
+  switch (rarity) {
+    case Rarity.Trash:
+      return "#999999";
+    case Rarity.Common:
+      return "hsl(130, 60%, 6%)";
+    case Rarity.Uncommon:
+      return "hsl(220, 60%, 6%)";
+    case Rarity.Rare:
+      return "hsl(280, 60%, 6%)";
+    case Rarity.Mythical:
+      return "hsl(40, 60%, 6%)";
+    case Rarity.Legendary:
+      return "hsl(10, 60%, 6%)";
+    case Rarity.Unique:
+      return "hsl(190, 60%, 6%)";
   }
 }
 
@@ -28,12 +66,28 @@ function rarityColor(rarity: Rarity): string {
 // the existing visual identity of the app.
 export function getCardColor(number: number): CardColor {
   const rarity = getCardRarity(number);
-  const color = rarityColor(rarity);
+  const cardColor = cardBackgroundColor(rarity);
+  const negativeColor = negativeBackgroundColor(rarity);
 
   // Invert card colors for negative numbers
   if (number >= 0) {
-    return { background: color, foreground: "#000000" };
+    return { background: cardColor, foreground: "#000000" };
   } else {
-    return { background: "#000000", foreground: color };
+    return { background: negativeColor, foreground: "#ffffff" };
+  }
+}
+
+export function getGridColor(number: number): CardColor {
+  const rarity = getCardRarity(number);
+  const cardColor = cardBackgroundColor(rarity);
+  const gridColor = gridBackgroundColor(rarity);
+  const negativeColor = negativeBackgroundColor(rarity);
+
+  // Invert card colors for negative numbers
+  if (number >= 0) {
+    return { background: gridColor, foreground: "#ffffff" };
+  } else {
+    return { background: negativeColor, foreground: "#ffffff" };
+    // return { background: "#000000", foreground: cardColor };
   }
 }

--- a/utils/math.ts
+++ b/utils/math.ts
@@ -1,0 +1,21 @@
+export function isPrime(number: number): boolean {
+  const root = Math.sqrt(number);
+  const absNumber = Math.abs(number);
+  if (absNumber == 0) {
+    return false;
+  }
+  for (let divisor = 2; divisor <= root; divisor++) {
+    if (absNumber % divisor == 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
+export function isSquare(number: number): boolean {
+  const absNumber = Math.abs(number);
+  if (absNumber == 0) {
+    return false;
+  }
+  return Number.isInteger(Math.sqrt(absNumber));
+}

--- a/utils/rarity.ts
+++ b/utils/rarity.ts
@@ -1,0 +1,33 @@
+export enum Rarity {
+  Trash,
+  Common,
+  Uncommon,
+  Rare,
+  Mythical,
+  Legendary,
+  Unique,
+}
+
+export function getCardRarity(number: number): Rarity {
+  const abs = number >= 0 ? number : -(number + 1);
+  // Special case -1 as Common due to two's compliment making it 0
+  if (number == -1) {
+    return Rarity.Common;
+  }
+
+  if (abs == 0) {
+    return Rarity.Trash;
+  } else if (abs > 0 && abs < 100) {
+    return Rarity.Common;
+  } else if (abs >= 100 && abs < 200) {
+    return Rarity.Uncommon;
+  } else if (abs >= 200 && abs < 300) {
+    return Rarity.Rare;
+  } else if (abs >= 300 && abs < 400) {
+    return Rarity.Mythical;
+  } else if (abs >= 400 && abs < 500) {
+    return Rarity.Legendary;
+  } else {
+    return Rarity.Unique;
+  }
+}


### PR DESCRIPTION
- Adds card rarity calculation
- Adds RPG-style rarity color scheme for cards and inverted negatives
- Updates grid view to use color scheme
- Adds card view to display card information (number, text, prime, square, rarity color)

![image](https://github.com/user-attachments/assets/971e60db-14fb-4be9-9cae-c284afbd97a5)
![image](https://github.com/user-attachments/assets/c17eb951-34b0-463d-b1de-0b6bcd8f6d5f)

**GridView**
[Screencast from 2025-01-25 11-20-45.webm](https://github.com/user-attachments/assets/d5aeceea-ba52-4e94-a617-31d6183b60f9)

**Card views / rarity**
[Screencast from 2025-01-25 11-11-15.webm](https://github.com/user-attachments/assets/a739caee-f0b7-4a0b-9775-2460bd23c89d)
