### PR TITLE
Add a custom theme, and attach dark and light mode

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -3,8 +3,10 @@ import { Drawer } from 'expo-router/drawer';
 import { Authenticator, useAuthenticator } from "@aws-amplify/ui-react-native";
 import { Amplify } from "aws-amplify";
 import { DataProvider } from "@/DataContext";
-import { MD3LightTheme, MD3Theme, PaperProvider } from "react-native-paper";
+import { MD3Theme, PaperProvider } from "react-native-paper";
 import { Theme as NavigationTheme, ThemeProvider } from "@react-navigation/native";
+import { CustomDarkTheme, CustomLightTheme } from "@/styles/customtheme";
+import { useColorScheme } from "react-native";
 
 Amplify.configure({
   Auth: {
@@ -21,7 +23,11 @@ Amplify.configure({
 });
 
 export default function RootLayout() {
-  const paperTheme = MD3LightTheme;
+    const colorScheme = useColorScheme();  
+    const paperTheme =
+      colorScheme === 'dark'
+        ? CustomDarkTheme
+        : CustomLightTheme;
 
   /** Following the example from `react-native-paper/src/core/theming.tsx`, convert an MD3Theme into a NavigationTheme */
   const getMirroredReactNavigationTheme = (baseTheme: MD3Theme): NavigationTheme => {

--- a/app/counts.tsx
+++ b/app/counts.tsx
@@ -1,7 +1,7 @@
 import { useData } from "@/DataContext";
 import { useEffect, useState } from "react";
-import { StyleSheet, Text, View } from "react-native";
-import { ActivityIndicator, DataTable } from "react-native-paper";
+import { StyleSheet, View } from "react-native";
+import { ActivityIndicator, DataTable, Text } from "react-native-paper";
 
 export default function Counts() {
   const { numberToCountMap,  isLoading } = useData();

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -7,8 +7,9 @@ import { useData } from "@/DataContext";
 import GrantButtonView from "@/components/GrantButtonView";
 import NewGrantCarouselView from "@/components/NewGrantCarouselView";
 import createApiClient from "@/clients/apiClient";
-import { ActivityIndicator, Button, MD3DarkTheme, PaperProvider, Text, useTheme } from "react-native-paper";
+import { ActivityIndicator, Button, PaperProvider, Text } from "react-native-paper";
 import versionInfo from "@/data/version.json";
+import { CustomDarkTheme } from "@/styles/customtheme";
 
 export default function Index() {
   const { signOut } = useAuthenticator();
@@ -58,7 +59,7 @@ export default function Index() {
   // The landing page intentionally and explicitly uses the "dark" theme for contrast with the
   // other pages. This means that it is not dynamically styled based on the users dark / light
   // color preference.
-  const darkTheme = MD3DarkTheme
+  const darkTheme = CustomDarkTheme
   const styles = getStyles(darkTheme.colors.surface)
 
   /** 

--- a/styles/customtheme.ts
+++ b/styles/customtheme.ts
@@ -1,0 +1,108 @@
+import { MD3DarkTheme, MD3LightTheme } from "react-native-paper";
+
+
+/** 
+ * Generated at https://callstack.github.io/react-native-paper/docs/guides/theming/ using the card rarity
+ * colors as a set of base colors.
+ * 
+ * The primary is the "uncommon" color from `getCardColor.ts`, the secondary is the "common" color, and
+ * the tertiary is "rare".
+ */
+export const CustomLightTheme = {
+    ...MD3LightTheme,
+    "colors": {
+        "primary": "rgb(42, 90, 184)",
+        "onPrimary": "rgb(255, 255, 255)",
+        "primaryContainer": "rgb(217, 226, 255)",
+        "onPrimaryContainer": "rgb(0, 25, 70)",
+        "secondary": "rgb(0, 110, 31)",
+        "onSecondary": "rgb(255, 255, 255)",
+        "secondaryContainer": "rgb(119, 254, 126)",
+        "onSecondaryContainer": "rgb(0, 34, 4)",
+        "tertiary": "rgb(141, 47, 188)",
+        "onTertiary": "rgb(255, 255, 255)",
+        "tertiaryContainer": "rgb(246, 217, 255)",
+        "onTertiaryContainer": "rgb(49, 0, 73)",
+        "error": "rgb(186, 26, 26)",
+        "onError": "rgb(255, 255, 255)",
+        "errorContainer": "rgb(255, 218, 214)",
+        "onErrorContainer": "rgb(65, 0, 2)",
+        "background": "rgb(254, 251, 255)",
+        "onBackground": "rgb(27, 27, 31)",
+        "surface": "rgb(254, 251, 255)",
+        "onSurface": "rgb(27, 27, 31)",
+        "surfaceVariant": "rgb(225, 226, 236)",
+        "onSurfaceVariant": "rgb(68, 70, 79)",
+        "outline": "rgb(117, 119, 128)",
+        "outlineVariant": "rgb(197, 198, 208)",
+        "shadow": "rgb(0, 0, 0)",
+        "scrim": "rgb(0, 0, 0)",
+        "inverseSurface": "rgb(48, 48, 52)",
+        "inverseOnSurface": "rgb(242, 240, 244)",
+        "inversePrimary": "rgb(177, 198, 255)",
+        "elevation": {
+        "level0": "transparent",
+        "level1": "rgb(243, 243, 251)",
+        "level2": "rgb(237, 238, 249)",
+        "level3": "rgb(231, 233, 247)",
+        "level4": "rgb(229, 232, 247)",
+        "level5": "rgb(224, 229, 245)"
+        },
+        "surfaceDisabled": "rgba(27, 27, 31, 0.12)",
+        "onSurfaceDisabled": "rgba(27, 27, 31, 0.38)",
+        "backdrop": "rgba(46, 48, 56, 0.4)"
+    }
+}
+
+/** 
+ * Generated at https://callstack.github.io/react-native-paper/docs/guides/theming/ using the card rarity
+ * colors as a set of base colors.
+ * 
+ * The primary is the "uncommon" color from `getCardColor.ts`, the secondary is the "common" color, and
+ * the tertiary is "rare".
+ */
+export const CustomDarkTheme = {
+    ...MD3DarkTheme,
+    "colors": {
+        "primary": "rgb(177, 198, 255)",
+        "onPrimary": "rgb(0, 44, 112)",
+        "primaryContainer": "rgb(0, 65, 157)",
+        "onPrimaryContainer": "rgb(217, 226, 255)",
+        "secondary": "rgb(90, 225, 101)",
+        "onSecondary": "rgb(0, 57, 12)",
+        "secondaryContainer": "rgb(0, 83, 21)",
+        "onSecondaryContainer": "rgb(119, 254, 126)",
+        "tertiary": "rgb(232, 179, 255)",
+        "onTertiary": "rgb(81, 0, 116)",
+        "tertiaryContainer": "rgb(114, 3, 162)",
+        "onTertiaryContainer": "rgb(246, 217, 255)",
+        "error": "rgb(255, 180, 171)",
+        "onError": "rgb(105, 0, 5)",
+        "errorContainer": "rgb(147, 0, 10)",
+        "onErrorContainer": "rgb(255, 180, 171)",
+        "background": "rgb(27, 27, 31)",
+        "onBackground": "rgb(228, 226, 230)",
+        "surface": "rgb(27, 27, 31)",
+        "onSurface": "rgb(228, 226, 230)",
+        "surfaceVariant": "rgb(68, 70, 79)",
+        "onSurfaceVariant": "rgb(197, 198, 208)",
+        "outline": "rgb(143, 144, 153)",
+        "outlineVariant": "rgb(68, 70, 79)",
+        "shadow": "rgb(0, 0, 0)",
+        "scrim": "rgb(0, 0, 0)",
+        "inverseSurface": "rgb(228, 226, 230)",
+        "inverseOnSurface": "rgb(48, 48, 52)",
+        "inversePrimary": "rgb(42, 90, 184)",
+        "elevation": {
+          "level0": "transparent",
+          "level1": "rgb(35, 36, 42)",
+          "level2": "rgb(39, 41, 49)",
+          "level3": "rgb(44, 46, 56)",
+          "level4": "rgb(45, 48, 58)",
+          "level5": "rgb(48, 51, 62)"
+        },
+        "surfaceDisabled": "rgba(228, 226, 230, 0.12)",
+        "onSurfaceDisabled": "rgba(228, 226, 230, 0.38)",
+        "backdrop": "rgba(46, 48, 56, 0.4)"
+      }
+}


### PR DESCRIPTION
Also curious on your thoughts on the custom theme @geoffmaddox!

I chose to use the "uncommon" blue for the core of the overall theme because otherwise, it really was just a lot of green on the landing page. The blue seems like a really good combination with all the other rarity colors too.

This primarily affects the styling of buttons, the header bar, and the data tables.

I also attached dark mode properly to all the pages that _aren't_ the number grid - the number grid is still always dark mode styled, but the rest of the app now respects the user preference.