### PR TITLE
Restore Green to Common and update negative grid color scheme to inverted

### DIFF
--- a/styles/getCardColor.ts
+++ b/styles/getCardColor.ts
@@ -81,13 +81,11 @@ export function getGridColor(number: number): CardColor {
   const rarity = getCardRarity(number);
   const cardColor = cardBackgroundColor(rarity);
   const gridColor = gridBackgroundColor(rarity);
-  const negativeColor = negativeBackgroundColor(rarity);
 
   // Invert card colors for negative numbers
   if (number >= 0) {
     return { background: gridColor, foreground: "#ffffff" };
   } else {
-    return { background: negativeColor, foreground: "#ffffff" };
-    // return { background: "#000000", foreground: cardColor };
+    return { background: "#000000", foreground: cardColor };
   }
 }

--- a/utils/rarity.ts
+++ b/utils/rarity.ts
@@ -15,9 +15,7 @@ export function getCardRarity(number: number): Rarity {
     return Rarity.Common;
   }
 
-  if (abs == 0) {
-    return Rarity.Trash;
-  } else if (abs > 0 && abs < 100) {
+  if (abs >= 0 && abs < 100) {
     return Rarity.Common;
   } else if (abs >= 100 && abs < 200) {
     return Rarity.Uncommon;


### PR DESCRIPTION
* Restores `0` to be `Common` for consistent coloration with the rest of the grid
* Updates the negative grid color scheme to be inverted (negative color rarities were very dark and didn't look distinct for higher numbers)