### PR TITLE
Fix the click for cards on iOS

### DIFF
--- a/app/index.tsx
+++ b/app/index.tsx
@@ -157,11 +157,9 @@ export default function Index() {
     }
 
     const triggerCollectionViewFromStartingCard = (card: number) => {
-        const allCards = [
-            ...numberToCountMap.keys().map((key) => {
-                return { number: key, isNew: false };
-            }),
-        ];
+        const allCards = [...numberToCountMap.keys()].map((key) => {
+            return { number: key, isNew: false };
+        });
 
         const startingIndex = allCards.findIndex(({ number }: CardEntry) => {
             return number === card;

--- a/components/GridView.tsx
+++ b/components/GridView.tsx
@@ -29,12 +29,12 @@ export default function GridView(props: GridViewProps) {
             const { backgroundColor, color } = getColors(number);
             elements.push(
                 <TouchableRipple
+                    key={colIndex}
                     onPress={() => {
                         props.pressedCardInGrid(number);
                     }}
                 >
                     <View
-                        key={colIndex}
                         style={{
                             ...styles.cell,
                             backgroundColor,


### PR DESCRIPTION
Tried this out on my phone after I saw it had landed, turns out iOS (or something along those lines) didn't have the right iterator map methods. This fixes things, verified in my iOS Simulator.

Also fixed an error with where the `key` was placed after I added an outer wrapper.

Note that nothing is "broken" per se, just "not working which is the same behavior as before."