### PR TITLE
Create a new "Stats" page with a selector for different time ranges

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -99,6 +99,13 @@ export default function RootLayout() {
                                             title: "Packs",
                                         }}
                                     />
+                                    <Drawer.Screen
+                                        name="stats"
+                                        options={{
+                                            drawerLabel: "Stats",
+                                            title: "Stats",
+                                        }}
+                                    />
                                 </Drawer>
                             </GestureHandlerRootView>
                         </DataProvider>

--- a/app/grants.tsx
+++ b/app/grants.tsx
@@ -1,6 +1,6 @@
 import { View, StyleSheet } from "react-native";
 import { useData } from "@/DataContext";
-import { Grant } from "@/model/Grant";
+import { getGrantString, Grant } from "@/model/Grant";
 import { ActivityIndicator, DataTable, Text } from "react-native-paper";
 import { useEffect, useState } from "react";
 import CopyNumbers from "@/components/CopyNumbers";
@@ -15,17 +15,6 @@ export default function Grants() {
                 <ActivityIndicator size="large" style={{ paddingTop: 32 }} />
             </View>
         );
-    }
-
-    function getGrantString(grant: Grant) {
-        const numbers: number[] = [];
-        for (const [number, count] of grant.numberToCountMap) {
-            for (let i = 0; i < count; i++) {
-                numbers.push(number);
-            }
-        }
-        numbers.sort((a, b) => a - b);
-        return numbers.join(", ");
     }
 
     function convertGrantToCardEntries(grant: Grant) {

--- a/app/stats.tsx
+++ b/app/stats.tsx
@@ -1,0 +1,547 @@
+import { ScrollView, View } from "react-native";
+import {
+    ActivityIndicator,
+    Divider,
+    SegmentedButtons,
+    Text,
+} from "react-native-paper";
+import { StyleSheet } from "react-native";
+import { useData } from "@/DataContext";
+import { getGrantString, Grant } from "@/model/Grant";
+import { useState } from "react";
+
+interface StatResult {
+    output: number[];
+    additionalText?: string;
+}
+
+interface StatEntry {
+    title: string;
+    calc: () => StatResult;
+}
+
+export default function Stats() {
+    const { grants: nonTimeBoundUnsafeGrants, isLoading } = useData();
+
+    // Must be a string to work with the SegmentedButton. Should be set to a whole number of
+    // days to consider on the stats page
+    const [daysToConsider, setDaysToConsider] = useState("0");
+
+    /** @returns the grants that we should consider when calculating status, properly filtered for the day range */
+    function getTimeBoundGrants() {
+        const daysAsNumber = Number(daysToConsider);
+        if (daysAsNumber == 0) {
+            return nonTimeBoundUnsafeGrants;
+        } else {
+            return nonTimeBoundUnsafeGrants.filter(
+                (grant) =>
+                    grant.timestamp.getTime() >
+                    Date.now() - 1000 * 60 * 60 * 24 * daysAsNumber,
+            );
+        }
+    }
+
+    /** @returns a number to count map that only includes numbers from the current day range */
+    function timeBoundNumberToCountMap() {
+        const grants = getTimeBoundGrants();
+        const numberToCountMapFromGrants = new Map<number, number>();
+
+        for (const grant of grants) {
+            for (const [num, count] of grant.numberToCountMap) {
+                const currentCount = numberToCountMapFromGrants.get(num) ?? 0;
+
+                numberToCountMapFromGrants.set(num, currentCount + count);
+            }
+        }
+        return numberToCountMapFromGrants;
+    }
+
+    /** A sorted flat-list of every number that has been pulled at least once */
+    const sortedFlatPulls = [
+        ...new Set(timeBoundNumberToCountMap().keys()),
+    ].sort(sortByValue);
+
+    if (isLoading) {
+        return (
+            <View>
+                <ActivityIndicator size="large" style={{ paddingTop: 32 }} />
+            </View>
+        );
+    }
+
+    /** @returns a string representation of the given iterable of numbers */
+    function numberString(numbers: Iterable<number>) {
+        const numberArray = [...numbers];
+        return numberArray
+            .slice(1)
+            .reduce((acc, num) => acc + `, ${num}`, `${numberArray[0]}`);
+    }
+
+    /** @returns a single stat-line view for the given statFunc */
+    function makeStatLine(entry: StatEntry, index: number) {
+        const result = entry.calc();
+
+        return (
+            <View key={index} style={styles.statLine}>
+                <View style={styles.singleStatEntry}>
+                    <Text style={{ flexBasis: 300 }}>{entry.title}</Text>
+                    <Text style={{ flexBasis: 150 }}>
+                        {result.output.length > 0
+                            ? numberString(result.output)
+                            : "None"}
+                    </Text>
+                    <Text style={{ flexBasis: 300 }}>
+                        {result.additionalText}
+                    </Text>
+                </View>
+                <Divider />
+            </View>
+        );
+    }
+
+    /** Reusable method to sort numbers by their value */
+    function sortByValue(a: number, b: number): number {
+        return a < b ? -1 : 1;
+    }
+
+    /** @returns the total absolute sum of numbers pulled in a given grant */
+    function absoluteSumForGrant(grant: Grant) {
+        let total = 0;
+        for (const [num, count] of grant.numberToCountMap) {
+            total += Math.abs(num) * count;
+        }
+        return total;
+    }
+
+    /**
+     * This mega-list contains all the stats we care about on this page. The methods in this list
+     * should interact with the "time bound" lists for grants and numbers, not the raw ones we get
+     * from useData.
+     */
+    const stats: StatEntry[] = [
+        /** Simple stats */
+        {
+            title: "Largest number",
+            calc: () => {
+                const largest = sortedFlatPulls[sortedFlatPulls.length - 1];
+
+                const rawOdds = Math.E ** (-(1 / 50) * largest);
+                return {
+                    output: [largest],
+                    additionalText: `Odds of pulling a larger number: ${(
+                        rawOdds * 100
+                    ).toFixed(5)}%`,
+                };
+            },
+        },
+        {
+            title: "Smallest number",
+            calc: () => {
+                const smallest = sortedFlatPulls[0];
+
+                // Don't give up the fact that negatives exist quite yet
+                if (smallest == 0) {
+                    return { output: [smallest] };
+                }
+
+                const rawOdds = Math.E ** (-(1 / 50) * Math.abs(smallest));
+
+                return {
+                    output: [smallest],
+                    additionalText: `Odds of pulling a smaller number: ${(
+                        rawOdds *
+                        100 *
+                        (smallest < 0 ? 0.1 : 1)
+                    ) // adjust for the odds of pulling a negative
+                        .toFixed(5)}%`,
+                };
+            },
+        },
+        {
+            title: "Total number of pulls",
+            calc: () => ({
+                output: [getTimeBoundGrants().length],
+            }),
+        },
+        {
+            title: "Total of all numbers pulled (absolute)",
+            calc: () => {
+                return {
+                    output: [
+                        getTimeBoundGrants().reduce(
+                            (acc, curr) => acc + absoluteSumForGrant(curr),
+                            0,
+                        ),
+                    ],
+                };
+            },
+        },
+        {
+            title: "Highest total in one pull (absolute)",
+            calc: () => {
+                let largestGrant: Grant = getTimeBoundGrants()[0];
+
+                for (const grant of getTimeBoundGrants()) {
+                    const total = absoluteSumForGrant(grant);
+                    if (total > absoluteSumForGrant(largestGrant)) {
+                        largestGrant = grant;
+                    }
+                }
+                return {
+                    output: [absoluteSumForGrant(largestGrant)],
+                    additionalText: getGrantString(largestGrant),
+                };
+            },
+        },
+        {
+            title: "Lowest total in one pull (absolute)",
+            calc: () => {
+                let smallestGrant: Grant = getTimeBoundGrants()[0];
+
+                for (const grant of getTimeBoundGrants()) {
+                    const total = absoluteSumForGrant(grant);
+                    if (total < absoluteSumForGrant(smallestGrant)) {
+                        smallestGrant = grant;
+                    }
+                }
+                return {
+                    output: [absoluteSumForGrant(smallestGrant)],
+                    additionalText: getGrantString(smallestGrant),
+                };
+            },
+        },
+        {
+            title: "Most frequently pulled number",
+            calc: () => {
+                let mostFrequentPull = [0];
+                let mostFrequentCount = 0;
+                for (const [num, count] of timeBoundNumberToCountMap()) {
+                    if (count == mostFrequentCount) {
+                        mostFrequentPull.push(num);
+                    } else if (count > mostFrequentCount) {
+                        mostFrequentPull = [num];
+                        mostFrequentCount = count;
+                    }
+                }
+                return {
+                    output: mostFrequentPull,
+                    additionalText: `Pulled ${mostFrequentCount} times`,
+                };
+            },
+        },
+        {
+            title: "Total unique numbers pulled",
+            calc: () => ({
+                output: [[...timeBoundNumberToCountMap().keys()].length],
+            }),
+        },
+        {
+            title: "Largest duplicate number",
+            calc: () => {
+                let largestDuplicate = 0;
+                let largestDuplicateCount = 0;
+                for (const [num, count] of timeBoundNumberToCountMap()) {
+                    if (count > 1 && num > largestDuplicate) {
+                        largestDuplicate = num;
+                        largestDuplicateCount = count;
+                    }
+                }
+                return {
+                    output: [largestDuplicate],
+                    additionalText: `Pulled ${largestDuplicateCount} times`,
+                };
+            },
+        },
+        {
+            title: "Most duplicates in a single pack",
+            calc: () => {
+                let mostDuplicatedNumbers: number[] = [];
+                let mostDuplicateCount = 0;
+                for (const grant of getTimeBoundGrants()) {
+                    for (const [num, count] of grant.numberToCountMap) {
+                        if (count == mostDuplicateCount) {
+                            mostDuplicatedNumbers.push(num);
+                        } else if (count > mostDuplicateCount) {
+                            mostDuplicatedNumbers = [num];
+                            mostDuplicateCount = count;
+                        }
+                    }
+                }
+                return {
+                    output: [mostDuplicateCount],
+                    additionalText: `${mostDuplicateCount} duplicates of ${numberString(
+                        mostDuplicatedNumbers,
+                    )}`,
+                };
+            },
+        },
+        {
+            title: "Largest total symmetric pair",
+            calc: () => {
+                /**
+                 * Recursively "narrow down" on the largest symmetric pair someone has. This method
+                 * iteratively swaps between testing a high number and a low number to jump to the
+                 * next absolute largest number that might have a partner, then moves on.
+                 */
+                function narrowDown(testNumber: number) {
+                    let lowBound: number;
+                    let highBound: number;
+                    if (testNumber < 0) {
+                        lowBound = testNumber;
+                        const res = [...sortedFlatPulls]
+                            .reverse()
+                            .find((val) => val <= Math.abs(lowBound));
+                        if (res == undefined) {
+                            return {
+                                output: [],
+                            };
+                        }
+                        highBound = res;
+                    } else {
+                        highBound = testNumber;
+                        const res = sortedFlatPulls.find(
+                            (val) => val >= highBound * -1,
+                        );
+                        if (res == undefined) {
+                            return {
+                                output: [],
+                            };
+                        }
+                        lowBound = res;
+                    }
+                    if (Math.abs(lowBound) == highBound) {
+                        return {
+                            output: [lowBound, highBound],
+                        };
+                    } else {
+                        return narrowDown(
+                            testNumber < 0 ? highBound : lowBound,
+                        );
+                    }
+                }
+
+                return narrowDown(Math.min(...sortedFlatPulls));
+            },
+        },
+        {
+            title: "Longest total sequence",
+            calc: () => {
+                let currentSequence = [sortedFlatPulls[0]];
+                let longestSequence = currentSequence;
+
+                for (let i = 0; i < sortedFlatPulls.length - 1; i++) {
+                    const curr = sortedFlatPulls[i];
+                    const next = sortedFlatPulls[i + 1];
+
+                    if (curr + 1 == next) {
+                        currentSequence.push(next);
+                    } else {
+                        if (currentSequence.length > longestSequence.length) {
+                            longestSequence = currentSequence;
+                        }
+                        currentSequence = [];
+                    }
+                }
+                return {
+                    output: [longestSequence.length],
+                    additionalText: `From ${longestSequence[0]} to ${
+                        longestSequence[longestSequence.length - 1]
+                    }`,
+                };
+            },
+        },
+        {
+            title: "Completed rows of numbers",
+            calc: () => {
+                // The first possibly full row
+                let rowStart = Math.ceil(sortedFlatPulls[0] / 10) * 10;
+                let rowsCompleted = 0;
+                function neededForFullRow(rowStart: number) {
+                    return [...Array(10).keys()].map((x) => x + rowStart);
+                }
+
+                while (rowStart < sortedFlatPulls[sortedFlatPulls.length - 1]) {
+                    if (
+                        neededForFullRow(rowStart).every((x) =>
+                            sortedFlatPulls.includes(x),
+                        )
+                    ) {
+                        rowsCompleted += 1;
+                    }
+                    rowStart += 10;
+                }
+
+                return {
+                    output: [rowsCompleted],
+                };
+            },
+        },
+        {
+            title: "Completed columns of numbers",
+            calc: () => {
+                // The first possibly full column
+                let columnStart = Math.ceil(sortedFlatPulls[0] / 100) * 100;
+                let columnsCompleted = 0;
+                function neededForFullColumn(columnStart: number) {
+                    let arr = [];
+                    for (let i = 0; i < 10; i++) {
+                        arr.push(columnStart + i * 10);
+                    }
+                    return arr;
+                }
+
+                while (
+                    columnStart < sortedFlatPulls[sortedFlatPulls.length - 1]
+                ) {
+                    for (let i = 0; i < 10; i++) {
+                        if (
+                            neededForFullColumn(columnStart - i).every((x) =>
+                                sortedFlatPulls.includes(x),
+                            )
+                        ) {
+                            columnsCompleted += 1;
+                        }
+                    }
+                    columnStart += 100;
+                }
+
+                return { output: [columnsCompleted] };
+            },
+        },
+        {
+            title: "Days passed since highest pull",
+            calc: () => {
+                const grantWithHighestPull = getTimeBoundGrants().find(
+                    (grant) =>
+                        [...grant.numberToCountMap.keys()].includes(
+                            sortedFlatPulls[sortedFlatPulls.length - 1],
+                        ),
+                );
+
+                if (!grantWithHighestPull) {
+                    return { output: [] };
+                }
+
+                const timeSince =
+                    Date.now() - grantWithHighestPull.timestamp.getTime();
+
+                const daysSince = Math.floor(timeSince / 1000 / 3600 / 24);
+
+                return {
+                    output: [daysSince],
+                    additionalText: `${grantWithHighestPull.timestamp.toDateString()}`,
+                };
+            },
+        },
+        {
+            title: "Most value from duplicates of a single number",
+            calc: () => {
+                let highest = 0;
+                let numAndCount: [number, number] = [0, 0];
+
+                for (const [num, count] of timeBoundNumberToCountMap()) {
+                    if (num * count > highest) {
+                        highest = num * count;
+                        numAndCount = [num, count];
+                    }
+                }
+
+                return {
+                    output: [highest],
+                    additionalText: `You have pulled ${numAndCount[1]} of the number ${numAndCount[0]}, for a total value of ${highest}`,
+                };
+            },
+        },
+        {
+            title: "Narrowest spread in a single pack",
+            calc: () => {
+                let narrowestGrant = getTimeBoundGrants()[0];
+                let narrowestDiff = Number.MAX_SAFE_INTEGER;
+
+                for (const grant of getTimeBoundGrants()) {
+                    const numbersInGrant = [
+                        ...grant.numberToCountMap.keys(),
+                    ].sort(sortByValue);
+                    const smallest = numbersInGrant[0];
+                    const largest = numbersInGrant[numbersInGrant.length - 1];
+
+                    const difference = largest - smallest;
+                    if (difference < narrowestDiff) {
+                        narrowestDiff = difference;
+                        narrowestGrant = grant;
+                    }
+                }
+
+                return {
+                    output: [narrowestDiff],
+                    additionalText: getGrantString(narrowestGrant),
+                };
+            },
+        },
+        {
+            title: "Widest spread in a single pack",
+            calc: () => {
+                let widestGrant = getTimeBoundGrants()[0];
+                let widestDiff = 0;
+
+                for (const grant of getTimeBoundGrants()) {
+                    const numbersInGrant = [
+                        ...grant.numberToCountMap.keys(),
+                    ].sort(sortByValue);
+                    const smallest = numbersInGrant[0];
+                    const largest = numbersInGrant[numbersInGrant.length - 1];
+
+                    const difference = largest - smallest;
+                    if (difference > widestDiff) {
+                        widestDiff = difference;
+                        widestGrant = grant;
+                    }
+                }
+
+                return {
+                    output: [widestDiff],
+                    additionalText: getGrantString(widestGrant),
+                };
+            },
+        },
+    ];
+
+    return (
+        <View style={{ maxHeight: "100%" }}>
+            <SegmentedButtons
+                style={{ padding: 16 }}
+                value={daysToConsider}
+                onValueChange={setDaysToConsider}
+                buttons={[
+                    {
+                        value: "0",
+                        label: "All time",
+                    },
+                    { value: "14", label: "14 days" },
+                    { value: "7", label: "7 days" },
+                ]}
+            />
+            <ScrollView>
+                <View style={styles.container}>
+                    {stats.map((item, index) => makeStatLine(item, index))}
+                </View>
+            </ScrollView>
+        </View>
+    );
+}
+
+const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+        flexDirection: "column",
+        gap: 8,
+        padding: 16,
+    },
+    statLine: {
+        gap: 8,
+    },
+    singleStatEntry: {
+        flexDirection: "row",
+        gap: 8,
+    },
+});

--- a/model/Grant.ts
+++ b/model/Grant.ts
@@ -2,3 +2,14 @@ export type Grant = {
     timestamp: Date;
     numberToCountMap: Map<number, number>;
 };
+
+export function getGrantString(grant: Grant) {
+    const numbers: number[] = [];
+    for (const [number, count] of grant.numberToCountMap) {
+        for (let i = 0; i < count; i++) {
+            numbers.push(number);
+        }
+    }
+    numbers.sort((a, b) => a - b);
+    return numbers.join(", ");
+}


### PR DESCRIPTION
This includes most of the stats I could think of, as well as a lot of stats people have asked for from Slack.

As people collect more and more numbers, fun stats like this are going to get harder to calculate independently, so hopefully this also acts as a framework for other interesting stats as people come up with them.

Very open to any and all feedback, including stuff like "that's a weird stat" or "X stat is better" or "your calculation for Y stat is wrong."

This was a lot of fun, mostly because lots of these individual stats were fun coding brain teasers!

<img width="600" alt="image" src="https://github.com/user-attachments/assets/4582dfe4-7749-4e33-9a42-0cc3befd0c95" />
<img width="200" alt="image" src="https://github.com/user-attachments/assets/95f6d5ee-ee66-42f6-8a1e-1b613fa42bd7" />

